### PR TITLE
simplify <pre><code></code></pre> to <pre></pre>

### DIFF
--- a/internal/cli/cmdPush.go
+++ b/internal/cli/cmdPush.go
@@ -91,7 +91,7 @@ func (c *CommandPush) pushTranslation(g *Global, file string) error {
 	}
 
 	if !c.Raw {
-		if t.Body, err = c.converter.ConvertToHTML(t.Body); err != nil {
+		if t.Body, err = c.converter.ConvertToHTML(g.Config.SimplifyPreCode, t.Body); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DefailtUserSegmentID     *int   `yaml:"default_user_segment_id" description:"Default user segment ID"`
 	NotifySubscribers        bool   `yaml:"notify_subscribers" description:"Notify subscribers when creating or updating articles" default:"false"`
 	ContentsDir              string `yaml:"contents_dir" description:"Path to the contents directory" default:"."`
+	SimplifyPreCode          bool   `yaml:"simplify_pre_code" description:"Simplify pre code blocks" default:"false"`
 }
 
 func (c *Config) Validation() error {

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"bytes"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -18,7 +19,7 @@ import (
 )
 
 type Converter interface {
-	ConvertToHTML(markdown string) (string, error)
+	ConvertToHTML(SimplifyPreCode bool, markdown string) (string, error)
 	ConvertToMarkdown(html string) (string, error)
 }
 
@@ -57,10 +58,15 @@ func NewConverter() Converter {
 	return &converterImpl{markdown, html}
 }
 
-func (c *converterImpl) ConvertToHTML(markdown string) (string, error) {
+func (c *converterImpl) ConvertToHTML(SimplifyPreCode bool, markdown string) (string, error) {
 	var buf bytes.Buffer
 	err := c.markdown.Convert([]byte(markdown), &buf)
-	return buf.String(), err
+	s := buf.String()
+	if SimplifyPreCode {
+		re := regexp.MustCompile(`(?s)<pre><code.*?>(.*?)</code></pre>`)
+		s = re.ReplaceAllString(s, "<pre>$1</pre>")
+	}
+	return s, err
 }
 
 func (c *converterImpl) ConvertToMarkdown(html string) (string, error) {

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -63,7 +63,7 @@ func (c *converterImpl) ConvertToHTML(SimplifyPreCode bool, markdown string) (st
 	err := c.markdown.Convert([]byte(markdown), &buf)
 	s := buf.String()
 	if SimplifyPreCode {
-		re := regexp.MustCompile(`(?s)<pre><code.*?>(.*?)</code></pre>`)
+		re := regexp.MustCompile(`(?s)<pre>\n?<code.*?>(.*?)</code></pre>`)
 		s = re.ReplaceAllString(s, "<pre>$1</pre>")
 	}
 	return s, err

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -35,7 +35,7 @@ func TestConvertToHTML_Div(t *testing.T) {
 	c := NewConverter()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)
+			actualHTMLContent, _ := c.ConvertToHTML(false, tc.markdown)
 			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
 				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
 			}
@@ -89,7 +89,65 @@ func TestConvertToHTML_Headings(t *testing.T) {
 	c := NewConverter()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)
+			actualHTMLContent, _ := c.ConvertToHTML(false, tc.markdown)
+			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
+				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
+			}
+		})
+	}
+}
+
+func TestConvertToHTML_Pre(t *testing.T) {
+	testCases := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "simple code block",
+			markdown: "```\nthis is a test content\n```\n",
+			expected: "<pre><code>this is a test content\n</code></pre>\n",
+		},
+		{
+			name:     "code block with language",
+			markdown: "```ruby\nthis is a test content\n```\n",
+			expected: "<pre><code class=\"language-ruby\">this is a test content\n</code></pre>\n",
+		},
+	}
+
+	c := NewConverter()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualHTMLContent, _ := c.ConvertToHTML(false, tc.markdown)
+			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
+				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
+			}
+		})
+	}
+}
+
+func TestConvertToHTML_SimplifyPre(t *testing.T) {
+	testCases := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "simple code block and simplify",
+			markdown: "```\nthis is a test content\n```\n",
+			expected: "<pre>this is a test content\n</pre>\n",
+		},
+		{
+			name:     "code block with language and simplify",
+			markdown: "```ruby\nthis is a test content\n```\n",
+			expected: "<pre>this is a test content\n</pre>\n",
+		},
+	}
+
+	c := NewConverter()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualHTMLContent, _ := c.ConvertToHTML(true, tc.markdown)
 			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
 				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
 			}


### PR DESCRIPTION
Goldmark always converts code block to `<pre><code.*>...</code></pre>` style https://github.com/yuin/goldmark/blob/master/renderer/html/html.go ,
but this makes unwanted result in Zendesk page.

This PR implements to remove `<code>`, `<code class="...">` and `</code>` strings  in `pre` element when `simplify_pre_code: true` on config yaml.

Original result
```
<pre><code>this is a test content
</code></pre>

<pre><code class="language-ruby">this is a test content
</code></pre>
```

Replaced result
```
<pre>this is a test content
</pre>

<pre>this is a test content
</pre>
```